### PR TITLE
Fix a bug in the word split regex

### DIFF
--- a/src/main/java/com/koverse/example/spark/JavaWordCountTransform.java
+++ b/src/main/java/com/koverse/example/spark/JavaWordCountTransform.java
@@ -55,7 +55,7 @@ public class JavaWordCountTransform extends JavaSparkTransform {
 
     // for each Record, tokenize the specified text field and count each occurrence
     final String fieldName = context.getParameters().get(TEXT_FIELD_NAME_PARAMETER);
-    final JavaWordCounter wordCounter = new JavaWordCounter(fieldName, "['\".?!,:;\\s]");
+    final JavaWordCounter wordCounter = new JavaWordCounter(fieldName, "['\".?!,:;\\s]+");
     
     return wordCounter.count(inputRecordsRdd);
   }

--- a/src/test/java/com/koverse/example/spark/JavaWordCounterTest.java
+++ b/src/test/java/com/koverse/example/spark/JavaWordCounterTest.java
@@ -31,7 +31,7 @@ public class JavaWordCounterTest  extends SharedJavaSparkContext {
     JavaRDD<SimpleRecord> inputRecordsRdd = jsc().parallelize(Lists.newArrayList(record0, record1));
     
     // Create and run the word counter to get the output RDD
-    JavaWordCounter wordCounter = new JavaWordCounter("text", "['\".?!,:;\\s]");
+    JavaWordCounter wordCounter = new JavaWordCounter("text", "['\".?!,:;\\s]+");
     JavaRDD<SimpleRecord> outputRecordsRdd = wordCounter.count(inputRecordsRdd);
     
     assertEquals(outputRecordsRdd.count(), 10);


### PR DESCRIPTION
An extremely minor fix to prevent multiple split/whitespace characters in a row from creating empty "words" of length 0.