### PR TITLE
updated java/scala pom to Koverse 2.8.0, places license header where …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ limitations under the License.
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <koverse.version>2.3.5</koverse.version>
+    <koverse.version>2.8.0</koverse.version>
   </properties>
 
   <!-- Project Metadata specific to your organization -->
@@ -53,6 +53,11 @@ limitations under the License.
       <id>cpfreem</id>
       <name>Chad Freeman</name>
       <email>chadfreeman@koverse.com</email>
+    </developer>
+    <developer>
+      <id>maryrogers</id>
+      <name>Mary Rogers</name>
+      <email>maryrogers@koverse.com</email>
     </developer>
   </developers>
   <issueManagement>
@@ -203,7 +208,7 @@ limitations under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>koverse-maven-plugin</artifactId>
-        <version>${koverse.version}</version>
+        <version>2.0.9</version>
         <configuration>
           <goal>deploy</goal>
         </configuration>

--- a/python/assembly.xml
+++ b/python/assembly.xml
@@ -1,3 +1,18 @@
+<!--
+Copyright 2016 Koverse, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 <assembly
         xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/python/description.yaml
+++ b/python/description.yaml
@@ -1,3 +1,17 @@
+#   Copyright 2018 Koverse, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
 id: python-word-count-example
 name: Python Word Count Example
 description: This is the Python Word Count Example Transform

--- a/python/pom.xml
+++ b/python/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2016 Koverse, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/python/test.py
+++ b/python/test.py
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Koverse, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import unittest
 
 from koverse.transformTest import PySparkTransformTestRunner


### PR DESCRIPTION
…it was required by rat

Tested on pwc-kyv-test cluster. All Java/Scala Word Count Examples were successful with identical outcomes. Scala data frame word count tokenized spaces as a word resulting in one more word that the other two transforms.
http://pwc-kyv-test.koverse.com:7080/#/data-sets/koverse_spark_example_dataframe_word_count_20181016_171257_271/overview
http://pwc-kyv-test.koverse.com:7080/#/data-sets/koverse_spark_examples_word_count_20181016_171036_131/overview
pwc-kyv-test.koverse.com:7080/#/data-sets/koverse_spark_examples_word_count_scala_20181016_171436_165/overview